### PR TITLE
Remove version specific requirement

### DIFF
--- a/PinnedItem.psm1
+++ b/PinnedItem.psm1
@@ -36,7 +36,7 @@ namespace System.File.PSItem
         public PinnedType Type;
     }
 }
-"@ -Language CSharpVersion3
+"@ -Language CSharp
 #endregion Define Custom Object
 
 #region Load Functions


### PR DESCRIPTION
There are many new releases of csharp which run with different .Net frameworks now.  Removing versioning will allow us to execute on wider range of environments without having to download older framework packages.